### PR TITLE
Security Fix for RCE on "pdf-toolz" - huntr.dev

### DIFF
--- a/PDF2Image.js
+++ b/PDF2Image.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const WithTmpDir = require('with-tmp-dir-promise').WithTempDir;
 const exec = require('mz/child_process').execFile;
 const {requireNativeExecutableSync} = require('require-native-executable');
+const { execFile } = require('child_process');
 
 requireNativeExecutableSync('gm');
 
@@ -14,7 +15,7 @@ async function pdfToImage (pdfBuf, imgtype = 'jpg', dpi = 200) {
         // Write input files
         await fs.writeFile(srcpath, pdfBuf);
         // Convert
-        const cmd = `gm convert +adjoin -format ${imgtype} -density ${dpi} ${srcpath} -quality 95 ${outpath}`;
+        var cmd = `gm convert +adjoin -format ${imgtype} -density ${dpi} ${srcpath} -quality 95 ${outpath}`;
         cmd = cmd.split(' ');
         await execFile(cmd[0], cmd.slice(1));
         // Read all the files

--- a/PDF2Image.js
+++ b/PDF2Image.js
@@ -2,7 +2,7 @@ const fs = require('mz/fs');
 const path = require('path');
 const _ = require('lodash');
 const WithTmpDir = require('with-tmp-dir-promise').WithTempDir;
-const exec = require('mz/child_process').exec;
+const exec = require('mz/child_process').execFile;
 const {requireNativeExecutableSync} = require('require-native-executable');
 
 requireNativeExecutableSync('gm');
@@ -15,7 +15,8 @@ async function pdfToImage (pdfBuf, imgtype = 'jpg', dpi = 200) {
         await fs.writeFile(srcpath, pdfBuf);
         // Convert
         const cmd = `gm convert +adjoin -format ${imgtype} -density ${dpi} ${srcpath} -quality 95 ${outpath}`;
-        await exec(cmd);
+        cmd = cmd.split(' ');
+        await execFile(cmd[0], cmd.slice(1));
         // Read all the files
         const files = await fs.readdir(tmpdir);
         const imgs = files.filter(file => _.endsWith(file, `.${imgtype}`)).sort();


### PR DESCRIPTION
https://huntr.dev/users/Asjidkalam has fixed the RCE on "pdf-toolz" vulnerability 🔨. Asjidkalam has been awarded $25 for fixing the vulnerability through the huntr bug bounty program 💵. Think you could fix a vulnerability like this?
           
Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/pdf-toolz/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/pdf-toolz/1/README.md

### User Comments:

### 📊 Metadata *

Command injection vulnerability 
#### Bounty URL:  https://www.huntr.dev/bounties/1-npm-pdf-toolz

### ⚙️ Description *

The pdf-toolz module is vulnerable against arbitrary command injection due to the fact some inputs given by the user are unsafely processed and executed. The argument options can be controlled by users without any sanitization. It was using `exec()` function which is vulnerable to **Command Injection** if it accepts user input and it goes through any sanitization or escaping.

### 💻 Technical Description *

The use of the `child_process` function `exec()` is highly discouraged if you accept user input and don't sanitize/escape them. I replaced it with `execFile()` which mitigates any possible Command Injections as it accepts input as arrays.

### 🐛 Proof of Concept (PoC) *

The PoC given in the bounty was incorrect, here's the PoC:
Install the package and run the below code, you'll need to have a PDF to test:
```javascript
const fs = require('mz/fs');
const {pdfToImage} = require('pdf-toolz/PDF2Image');

async function exportPageImages() {
    const pdf = await fs.readFile('portrait-singlepage.pdf');
    const pageImages = await pdfToImage(pdf, 'png; touch HACKED #//', 400);
    
    await fs.writeFile("page-1.png", pageImages[0]);
    await fs.writeFile("page-2.png", pageImages[1]);
    await fs.writeFile("page-3.png", pageImages[2]);
}
exportPageImages()
```
A file named `HACKED` will be created in the current working directory.

![image](https://user-images.githubusercontent.com/16708391/92505489-ca4b5a80-f221-11ea-8de9-d794a3e43aa4.png)



### 🔥 Proof of Fix (PoF) *

After applying the fix, run the PoC again and no files will be created. Hence command injection is mitigated.

![image](https://user-images.githubusercontent.com/16708391/92505837-2a420100-f222-11ea-891f-d7c72b521546.png)



### 👍 User Acceptance Testing (UAT)

Only `execFile` is used, no breaking changes introduced.
